### PR TITLE
Fix for #218 - use raw attachment bytes to prevent corruption

### DIFF
--- a/msg_parser/email_builder.py
+++ b/msg_parser/email_builder.py
@@ -104,10 +104,9 @@ class EmailFormatter(object):
             if data is None:
                 continue
 
-            if isinstance(data, bytes):
-                data = data.decode("utf-8", "ignore")
-
             if maintype == "text" or "message" in maintype:
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8", "ignore")
                 attach = MIMEText(data, _subtype=subtype)
             elif maintype == "image":
                 attach = MIMEImage(data, _subtype=subtype)

--- a/msg_parser/msg_parser.py
+++ b/msg_parser/msg_parser.py
@@ -223,7 +223,12 @@ class Message(object):
         )
 
         if property_value:
-            property_detail = {property_name: property_value}
+            # If the propery is the data of the attachment it has to be provided raw to preven corruption
+            if property_name == 'AttachDataObject':
+                property_detail = {property_name: raw_content}
+            # Otherwhisle use the olefile lib to get the value
+            else:
+                property_detail = {property_name: property_value}
         else:
             property_detail = None
 


### PR DESCRIPTION
Same as fix suggested by  @danieldiezmallo but keep `data.decode("utf-8", "ignore")` in` _process_attachments` when MimeType is text.