### PR TITLE
when detecting html, allow for xhtml

### DIFF
--- a/msg_parser/email_builder.py
+++ b/msg_parser/email_builder.py
@@ -57,7 +57,7 @@ class EmailFormatter(object):
         # Required Email body content
         body_content = self.msg_obj.body
         if body_content:
-            if "<html>" in body_content:
+            if "<html" in body_content:
                 body_type = "html"
             else:
                 body_type = "plain"


### PR DESCRIPTION
some html emails have additional attrs (like an xml namespace) in the `<html>` tag, so that `"<html>" in body_content` is false, e.g. `<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>`

msg_parser failed in parsing this email, outputting an .eml file marked as content-type `text/plain` but containing HTML tags. 

This one-byte proposed change causes msg_parser to behave correctly, outputting an HTML-based .eml file that's parsed appropriately by other libraries.

Unfortunately, I cannot include the file that caused this error; it's confidential. I was unable to find or generate a non-confidential file that exhibits the same properties. If you have any tips on how to do so using only Mac Outlook (or maybe Outlook Web Access), I'd be happy to do so.